### PR TITLE
fix: enable in shift

### DIFF
--- a/conful.js
+++ b/conful.js
@@ -8,7 +8,7 @@ document.addEventListener('keydown', function(event) {
         var cursorPosition = selection.anchorOffset;
 
         // 入力カーソル位置が 1 以外から 1 に変わった場合
-        if ((previous_cursor_position != 1 && previous_cursor_position != 0) && cursorPosition === 1 && event.key === "Process") {
+        if ((previous_cursor_position != 1 && previous_cursor_position != 0) && cursorPosition === 1 &&( event.key === "Process" || event.key=="Shift")) {
             activeField.focus();
             document.execCommand('insertText', false, ' ');
         }


### PR DESCRIPTION
予測変換の確定前に「！」や「？」などのShiftを用いた文字を入力すると文頭に行ってしまうことの修正

## Before
https://github.com/zusizusi/conflu-japanese-issue-chrome-extension/assets/53928021/a52ce219-fdc2-45cc-9dd1-3c91e4c222d4

## After
https://github.com/zusizusi/conflu-japanese-issue-chrome-extension/assets/53928021/769d1849-614f-450d-8956-823f07dac39d


